### PR TITLE
Graceful shutdown of server

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,4 +4,5 @@ type Config struct {
 	Port         string `default:"http"`
 	PasswordCost int    `default:"12" split_words:"true"`
 	DatabaseUrl  string `default:"postgres://postgres:root@localhost:5432/postgres?sslmode=disable" split_words:"true"`
+	ShutdownTime int    `default:"30" split_words:"true"`
 }

--- a/main.go
+++ b/main.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"github.com/Sirupsen/logrus"
 	"github.com/andrewburian/powermux"
 	"github.com/go-pg/pg"
 	"github.com/kelseyhightower/envconfig"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 )
 
 const (
@@ -72,6 +77,26 @@ func main() {
 
 	// start the http server
 	logrus.WithField("port", conf.Port).Info("Server starting")
-	err = http.ListenAndServe(":"+conf.Port, mux)
+	server := &http.Server{
+		Addr:    ":" + conf.Port,
+		Handler: mux,
+	}
+
+	// Trap TERM and INT signals
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
+
+	// Signals kill the server
+	go func(c <-chan os.Signal) {
+		select {
+		case _ = <-c:
+			shutdownCtx, cancelFunc := context.WithTimeout(context.Background(), time.Minute)
+			server.Shutdown(shutdownCtx)
+			cancelFunc()
+		}
+	}(sigChan)
+
+	// Run the server
+	err = server.ListenAndServe()
 	logrus.Fatal(err)
 }

--- a/main.go
+++ b/main.go
@@ -90,7 +90,8 @@ func main() {
 	go func(c <-chan os.Signal) {
 		select {
 		case sig := <-c:
-			shutdownCtx, cancelFunc := context.WithTimeout(context.Background(), time.Minute)
+			shutdownTime := time.Duration(conf.ShutdownTime) * time.Second
+			shutdownCtx, cancelFunc := context.WithTimeout(context.Background(), shutdownTime)
 			logrus.WithField("signal", sig).Warn("Trapped signal")
 			server.Shutdown(shutdownCtx)
 			cancelFunc()

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 	authRoute := mux.Route(ROUTE_AUTH)
 	passwordHandler.Setup(authRoute.Route(ROUTE_PASSWORD))
 
-	// start the http server
+	// setup the http server
 	logrus.WithField("port", conf.Port).Info("Server starting")
 	server := &http.Server{
 		Addr:    ":" + conf.Port,
@@ -99,5 +99,13 @@ func main() {
 
 	// Run the server
 	err = server.ListenAndServe()
+
+	// clean exit on server close
+	if err == http.ErrServerClosed {
+		logrus.Info("Server shut down")
+		return
+	}
+
+	// Error otherwise
 	logrus.Fatal(err)
 }

--- a/main.go
+++ b/main.go
@@ -89,8 +89,9 @@ func main() {
 	// Signals kill the server
 	go func(c <-chan os.Signal) {
 		select {
-		case _ = <-c:
+		case sig := <-c:
 			shutdownCtx, cancelFunc := context.WithTimeout(context.Background(), time.Minute)
+			logrus.WithField("signal", sig).Warn("Trapped signal")
 			server.Shutdown(shutdownCtx)
 			cancelFunc()
 		}


### PR DESCRIPTION
Server will shutdown on `SIGINT` or `SIGTERM` gracefully, not interrupting any requests in flight