### PR TITLE
CORS handler for OPTIONS and Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@
 - `PORT` port to bind to (Default "http")
 - `DATABASE_URL` postgres connection string (Default to localhost)
 - `PASSWORD_COST` bcrypt cost value to use (Default 12)
+- `WEBAPP_ORIGIN` the web origin of the webapp for CORS (default "roomie-webapp.herokuapp.com")

--- a/config.go
+++ b/config.go
@@ -5,4 +5,5 @@ type Config struct {
 	PasswordCost int    `default:"12" split_words:"true"`
 	DatabaseUrl  string `default:"postgres://postgres:root@localhost:5432/postgres?sslmode=disable" split_words:"true"`
 	ShutdownTime int    `default:"30" split_words:"true"`
+	WebappOrigin string `default:"roomie-webapp.herokuapp.com" split_words:"true"`
 }

--- a/cors_middleware.go
+++ b/cors_middleware.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+type CorsHandler struct {
+	AllowedMethods []string
+	AllowedOrigins []string
+	AllowedHeaders []string
+}
+
+// Respond to OPTIONS requests
+func (h *CorsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Access-Control-Allow-Methods", strings.Join(h.AllowedMethods, ", "))
+	w.Header().Add("Access-Control-Allow-Headers", strings.Join(h.AllowedHeaders, ", "))
+	w.WriteHeader(http.StatusOK)
+}
+
+// Allow origins on all requests that may return a body that needs read
+func (h *CorsHandler) ServeHTTPMiddleware(w http.ResponseWriter, r *http.Request,
+	n func(http.ResponseWriter, *http.Request)) {
+
+	// Allow all requests access from approved origins
+	r.Header.Set("Access-Control-Allow-Origins", strings.Join(h.AllowedOrigins, ", "))
+	n(w, r)
+}

--- a/main.go
+++ b/main.go
@@ -56,6 +56,16 @@ func main() {
 
 	// Setup middleware
 
+	// We allow all methods through CORS, the router will respond to
+	// verbs that aren't implemented
+	corsMid := &CorsHandler{
+		AllowedOrigins: []string{conf.WebappOrigin},
+		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE"},
+		AllowedHeaders: []string{"Content-Type", "Authorization"},
+	}
+
+	mux.Route(ROUTE_AUTH).Middleware(corsMid).Options(corsMid)
+
 	// debug supersedes quiet
 	if *quiet {
 		logrus.SetLevel(logrus.ErrorLevel)


### PR DESCRIPTION
Allows methods GET, POST, PUT, DELETE, (and OPTIONS implicitly)
Allows `Content-Type` and `Authorization` headers
Only allows the webapp origin `$WEBAPP_ORIGIN`